### PR TITLE
Listen different address and push to pushgateway

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -121,7 +121,7 @@ func (p *Prometheus) getPushGatewayUrl() string {
 	if p.Ppg.Job == "" {
 		p.Ppg.Job = "gin"
 	}
-	return p.Ppg.PushGatewayURL + "/metrics/job/" + p.Ppg.Job + "/instances/" + h
+	return p.Ppg.PushGatewayURL + "/metrics/job/" + p.Ppg.Job + "/instance/" + h
 }
 
 func (p *Prometheus) sendMetricsToPushGateway(metrics []byte) {

--- a/middleware.go
+++ b/middleware.go
@@ -76,7 +76,7 @@ func (p *Prometheus) registerMetrics(subsystem string) {
 			Name:      "requests_total",
 			Help:      "How many HTTP requests processed, partitioned by status code and HTTP method.",
 		},
-		[]string{"code", "method", "handler"},
+		[]string{"code", "method", "handler", "host"},
 	)
 
 	if err := prometheus.Register(p.reqCnt); err != nil {
@@ -160,7 +160,7 @@ func (p *Prometheus) handlerFunc() gin.HandlerFunc {
 		resSz := float64(c.Writer.Size())
 
 		p.reqDur.Observe(elapsed)
-		p.reqCnt.WithLabelValues(status, c.Request.Method, c.HandlerName()).Inc()
+		p.reqCnt.WithLabelValues(status, c.Request.Method, c.HandlerName(), c.Request.Host).Inc()
 		p.reqSz.Observe(float64(<-reqSz))
 		p.resSz.Observe(resSz)
 	}

--- a/middleware.go
+++ b/middleware.go
@@ -1,7 +1,10 @@
 package ginprometheus
 
 import (
+	"bytes"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -20,20 +23,56 @@ type Prometheus struct {
 	router               *gin.Engine
 	listenAddress        string
 
+	Ppg PrometheusPushGateway
+
 	MetricsPath string
+}
+
+// PrometheusPushGateway contains the configuration for pushing to a Prometheus pushgateway (optional)
+type PrometheusPushGateway struct {
+
+	// Push interval in seconds
+	PushIntervalSeconds time.Duration
+
+	// Push Gateway URL in format http://domain:port
+	// where JOBNAME can be any string of your choice
+	PushGatewayURL string
+
+	// Local metrics URL where metrics are fetched from, this could be ommited in the future
+	// if implemented using prometheus common/expfmt instead
+	MetricsURL string
+
+	// pushgateway job name, defaults to "gin"
+	Job string
 }
 
 // NewPrometheus generates a new set of metrics with a certain subsystem name
 func NewPrometheus(subsystem string) *Prometheus {
+
 	p := &Prometheus{
 		MetricsPath: defaultMetricPath,
 	}
-
 	p.registerMetrics(subsystem)
 
 	return p
 }
 
+// SetPushGateway sends metrics to a remote pushgateway exposed on pushGatewayURL
+// every pushIntervalSeconds. Metrics are fetched from metricsURL
+func (p *Prometheus) SetPushGateway(pushGatewayURL, metricsURL string, pushIntervalSeconds time.Duration) {
+	p.Ppg.PushGatewayURL = pushGatewayURL
+	p.Ppg.MetricsURL = metricsURL
+	p.Ppg.PushIntervalSeconds = pushIntervalSeconds
+	p.startPushTicker()
+}
+
+// Set pushgateway job name, defaults to "gin"
+func (p *Prometheus) SetPushGatewayJob(j string) {
+	p.Ppg.Job = j
+}
+
+// SetListenAddress for exposing metrics on address. If not set, it will be exposed at the
+// same address of the gin engine that is being used
 func (p *Prometheus) SetListenAddress(address string) {
 	p.listenAddress = address
 	if p.listenAddress != "" {
@@ -66,6 +105,41 @@ func (p *Prometheus) runServer() {
 	if p.listenAddress != "" {
 		go p.router.Run(p.listenAddress)
 	}
+}
+
+func (p *Prometheus) getMetrics() []byte {
+	response, _ := http.Get(p.Ppg.MetricsURL)
+
+	defer response.Body.Close()
+	body, _ := ioutil.ReadAll(response.Body)
+
+	return body
+}
+
+func (p *Prometheus) getPushGatewayUrl() string {
+	h, _ := os.Hostname()
+	if p.Ppg.Job == "" {
+		p.Ppg.Job = "gin"
+	}
+	return p.Ppg.PushGatewayURL + "/metrics/job/" + p.Ppg.Job + "/instances/" + h
+}
+
+func (p *Prometheus) sendMetricsToPushGateway(metrics []byte) {
+	req, err := http.NewRequest("POST", p.getPushGatewayUrl(), bytes.NewBuffer(metrics))
+	client := &http.Client{}
+	_, err = client.Do(req)
+	if err != nil {
+		log.Error("Error sending to push gatway: " + err.Error())
+	}
+}
+
+func (p *Prometheus) startPushTicker() {
+	ticker := time.NewTicker(time.Second * p.Ppg.PushIntervalSeconds)
+	go func() {
+		for range ticker.C {
+			p.sendMetricsToPushGateway(p.getMetrics())
+		}
+	}()
 }
 
 func (p *Prometheus) registerMetrics(subsystem string) {


### PR DESCRIPTION
### Add the possibility of listening in a different address for metrics exposing

In some cases we don't want or we can't (I.E. having wildcards in gin router) expose /metrics under our app gin router.
We can expose /metrics in a separate router listening in a differerent address

If you want to expose /metrics in a different address call `SetListenAddress()` right after creating Prometheus

```
p := ginprometheus.NewPrometheus("gin")
p.SetListenAddress(":9091")
p.Use(r)

```
that will expose /metrics listening on all interfaces at port 9091.

### Push metrics to a remote prometheus pushgateway
Useful for short lived instances where prometheus server can't fetch metrics. (I.E. deployed in kubernetes or using autoscaling)
Use SetPushGateway(pushGatewayURL, metricsURL string, pushIntervalSeconds time.Duration) to set configuration and start pushing.

```
p := ginprometheus.NewPrometheus("gin")
p.SetListenAddress(":9090")
p.SetPushGateway("http://localhost:9091", "http://localhost:9090/metrics", 60)

p.Use(r)
```

`pushGatewayURL` refers to remote prometheus pushgateway which should be up and running
`metricsURL` refers to local metricsURL where metrics are read from and then pushed to pushGateway
with `pushIntervalSeconds` you can define push interval in seconds.

### Add host label to request count
`host` label is added to request count. Useful when using gin as a reverse proxy and several applications can responde.