### PR TITLE
use proper capitalization of logrus

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	log "github.com/sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 )
 
 var defaultMetricPath = "/metrics"


### PR DESCRIPTION
The actual capitalization for the logrus repo is github.com/Sirupsen/logrus. If you change it in your package, you will screw up anyone that imports your package from a case-sensitive filesystem (and tools like dep will complain, too).