### PR TITLE
Fixing logrus and adding comments

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 var defaultMetricPath = "/metrics"
@@ -66,7 +66,7 @@ func (p *Prometheus) SetPushGateway(pushGatewayURL, metricsURL string, pushInter
 	p.startPushTicker()
 }
 
-// Set pushgateway job name, defaults to "gin"
+// SetPushGatewayJob job name, defaults to "gin"
 func (p *Prometheus) SetPushGatewayJob(j string) {
 	p.Ppg.Job = j
 }
@@ -116,7 +116,7 @@ func (p *Prometheus) getMetrics() []byte {
 	return body
 }
 
-func (p *Prometheus) getPushGatewayUrl() string {
+func (p *Prometheus) getPushGatewayURL() string {
 	h, _ := os.Hostname()
 	if p.Ppg.Job == "" {
 		p.Ppg.Job = "gin"
@@ -125,7 +125,7 @@ func (p *Prometheus) getPushGatewayUrl() string {
 }
 
 func (p *Prometheus) sendMetricsToPushGateway(metrics []byte) {
-	req, err := http.NewRequest("POST", p.getPushGatewayUrl(), bytes.NewBuffer(metrics))
+	req, err := http.NewRequest("POST", p.getPushGatewayURL(), bytes.NewBuffer(metrics))
 	client := &http.Client{}
 	_, err = client.Do(req)
 	if err != nil {


### PR DESCRIPTION
See sirupsen/logrus#451 for details.
It is now recommended to not use the uppercase version of sirupsen/logrus but instead always use the lowercase. 
Also, from the README.md of the logrus project :

> Seeing weird case-sensitive problems? It's in the past been possible to import Logrus as both upper- and lower-case. Due to the Go package environment, this caused issues in the community and we needed a standard. Some environments experienced problems with the upper-case variant, so the lower-case was decided. Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed.

I also fixed a few comments. 