### PR TITLE
Add url label to request counter

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -150,7 +150,7 @@ func (p *Prometheus) registerMetrics(subsystem string) {
 			Name:      "requests_total",
 			Help:      "How many HTTP requests processed, partitioned by status code and HTTP method.",
 		},
-		[]string{"code", "method", "handler", "host"},
+		[]string{"code", "method", "handler", "host", "url"},
 	)
 
 	if err := prometheus.Register(p.reqCnt); err != nil {
@@ -232,7 +232,7 @@ func (p *Prometheus) handlerFunc() gin.HandlerFunc {
 		resSz := float64(c.Writer.Size())
 
 		p.reqDur.Observe(elapsed)
-		p.reqCnt.WithLabelValues(status, c.Request.Method, c.HandlerName(), c.Request.Host).Inc()
+		p.reqCnt.WithLabelValues(status, c.Request.Method, c.HandlerName(), c.Request.Host, c.Request.URL.String()).Inc()
 		p.reqSz.Observe(float64(reqSz))
 		p.resSz.Observe(resSz)
 	}


### PR DESCRIPTION
Hi! As your project has been recently introduced in https://github.com/chartmuseum/chartmuseum, we would like to add an extra `url` label to the request counter, which would be quite useful in this particular context. Also, would you consider a release soon?

Ref: @mattfarina, @davidovich and @jdolitsky