### PR TITLE
Expose HandlerFunc

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -335,17 +335,18 @@ func (p *Prometheus) registerMetrics(subsystem string) {
 
 // Use adds the middleware to a gin engine.
 func (p *Prometheus) Use(e *gin.Engine) {
-	e.Use(p.handlerFunc())
+	e.Use(p.HandlerFunc())
 	p.setMetricsPath(e)
 }
 
 // UseWithAuth adds the middleware to a gin engine with BasicAuth.
 func (p *Prometheus) UseWithAuth(e *gin.Engine, accounts gin.Accounts) {
-	e.Use(p.handlerFunc())
+	e.Use(p.HandlerFunc())
 	p.setMetricsPathWithAuth(e, accounts)
 }
 
-func (p *Prometheus) handlerFunc() gin.HandlerFunc {
+// HandlerFunc returns our middleware handler
+func (p *Prometheus) HandlerFunc() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.URL.String() == p.MetricsPath {
 			c.Next()


### PR DESCRIPTION
This PR will help in solving [issue 28](https://github.com/zsais/go-gin-prometheus/issues/28), using it, users will be able to configure `promhttp` manually. In case of  [issue 28](https://github.com/zsais/go-gin-prometheus/issues/28); disable Gzip. For example:

```
import (
	"github.com/gin-gonic/gin"
	"github.com/zsais/go-gin-prometheus"
	"github.com/prometheus/client_golang/prometheus"
	"github.com/prometheus/client_golang/prometheus/promhttp"
)

ginRouter := gin.New()
ginRouter.Use(gzip.Gzip(gzip.BestCompression))

// Add Prometheus
p := ginprometheus.NewPrometheus("gin")
// p.Use(ginRouter) // DON'T use this!, Instead:

ginRouter.Use(p.HandlerFunc())
h := promhttp.InstrumentMetricHandler(
	prometheus.DefaultRegisterer, HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{DisableCompression: true}),
)
ginRouter.GET(p.MetricsPath, func(c *gin.Context) {
	h.ServeHTTP(c.Writer, c.Request)
})

// Run
ginRouter.Run(":8080")
```

Now browse:
`http://localhost:8080/metrics` - **IT WORKS!**

There is no need for backward compatibility (make `HandlerFunc` call `handlerFunc`), the method was "hidden".

