### PR TITLE
add objectives for summary

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -299,18 +299,20 @@ func NewMetric(m *Metric, subsystem string) prometheus.Collector {
 	case "summary_vec":
 		metric = prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
-				Subsystem: subsystem,
-				Name:      m.Name,
-				Help:      m.Description,
+				Subsystem:  subsystem,
+				Name:       m.Name,
+				Help:       m.Description,
+				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 			},
 			m.Args,
 		)
 	case "summary":
 		metric = prometheus.NewSummary(
 			prometheus.SummaryOpts{
-				Subsystem: subsystem,
-				Name:      m.Name,
-				Help:      m.Description,
+				Subsystem:  subsystem,
+				Name:       m.Name,
+				Help:       m.Description,
+				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 			},
 		)
 	}


### PR DESCRIPTION
While creating `Summary` typed metric,  `Objectives` were ommited. Maybe it is inconvenient for users to view and monitor metrics. So I add some typical objectives for metric with type `Summary`. 
