### PR TITLE
Feaure/add status override from context

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -2,6 +2,7 @@ package ginprometheus
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -100,7 +101,8 @@ type Prometheus struct {
 	ReqCntURLLabelMappingFn RequestCounterURLLabelMappingFn
 
 	// gin.Context string to use as a prometheus URL label
-	URLLabelFromContext string
+	URLLabelFromContext       string
+	StatusOverrideFromContext string
 }
 
 // PrometheusPushGateway contains the configuration for pushing to a Prometheus pushgateway (optional)
@@ -367,6 +369,13 @@ func (p *Prometheus) HandlerFunc() gin.HandlerFunc {
 		c.Next()
 
 		status := strconv.Itoa(c.Writer.Status())
+		if p.StatusOverrideFromContext != "" {
+			statusFromContext, found := c.Get(p.StatusOverrideFromContext)
+			if found {
+				status = fmt.Sprintf("%v", statusFromContext)
+			}
+		}
+
 		elapsed := float64(time.Since(start)) / float64(time.Second)
 		resSz := float64(c.Writer.Size())
 


### PR DESCRIPTION
This feature is about to override code label base on context value.

use StatusOverrideFromContext


	p := ginprometheus.NewPrometheus("gin")
	p.StatusOverrideFromContext = append(p.StatusOverrideFromContext, "code")
	p.StatusOverrideFromContext = append(p.StatusOverrideFromContext, "mycode")

and set  gin's context

```
        r.GET("/", func(c *gin.Context) {
		c.Set("code", "888")
		c.JSON(200, "Hello world!")
	})
```

See example at [here](https://github.com/zoftdev/go-gin-prometheus/blob/master/example/example.go)